### PR TITLE
进入竞技场，倒计时不执行。（偶发异常）

### DIFF
--- a/src/battle/BattleField.js
+++ b/src/battle/BattleField.js
@@ -660,10 +660,12 @@ var BattleField = cc.Class.extend({
      */
     prepareBattle: function (stage) {
         unschedule(this);
-        this.initBattleEnemies(stage);
-        this.updateEnemyLife();
-        this.notifyUpdateTopPanelStageState();
-        PlayerData.updateIntoBattleTime();
+        if(!this.arenaBattle){
+            this.initBattleEnemies(stage);
+            this.updateEnemyLife();
+            this.notifyUpdateTopPanelStageState();
+            PlayerData.updateIntoBattleTime();
+        }
     },
 
     showFairy: function () {

--- a/src/battle/CCSUnit.js
+++ b/src/battle/CCSUnit.js
@@ -17,17 +17,17 @@ var CCSUnit = cc.Node.extend({
      */
     initSprite: function (file, nodeName, defaultAnimName) {
         var json = ccs.load(file);
-        this.node = nodeName ? json.node.getChildByName(nodeName) : json.node;
-        this.node.removeFromParent();
+        node = nodeName ? json.node.getChildByName(nodeName) : json.node;
+        node.removeFromParent();
         this.animation = json.action;
         {
             //去除CCS导出文件位移会自带缓动效果的问题
             var timelines = this.animation.getTimelines();
             removeCCSAnimationDefaultTween(timelines);
         }
-        this.node.runAction(this.animation);
-        this.setContentSize(this.node.getContentSize());
-        this.addChild(this.node);
+        node.runAction(this.animation);
+        this.setContentSize(node.getContentSize());
+        this.addChild(node);
         if (this.debug) {
             var debugRect = new cc.DrawNode();
             this.addChild(debugRect);


### PR DESCRIPTION
由于普通关卡战役后，会延时加载下批敌人，当进入竞技场同时，刚好再加载下一关敌人，但是竞技状态已修改为true，会将原关卡敌人数据加载到ArenaHeroUnit中。
