### PR TITLE
优化

### DIFF
--- a/src/battle/ActiveSkill.js
+++ b/src/battle/ActiveSkill.js
@@ -68,6 +68,18 @@ var ActiveSkill = cc.Class.extend({
                 this.effect = effects[j].type;
             }
         }
+        customEventHelper.bindListener(EVENT.FIGHT_ARENA_BATTLE, function () {
+            if (this.type !== this.TYPE_BUFF)
+                this.releaseEffectAnimations();
+        }.bind(this));
+        customEventHelper.bindListener(EVENT.LOSE_ARENA_BATTLE, function () {
+            if (this.type !== this.TYPE_BUFF)
+                this.releaseEffectAnimations();
+        }.bind(this));
+        customEventHelper.bindListener(EVENT.WIN_ARENA_BATTLE, function () {
+            if (this.type !== this.TYPE_BUFF)
+                this.releaseEffectAnimations();
+        }.bind(this));
     },
 
     loadSkillEffectRes: function (filename, num, defaultAnimationName) {
@@ -116,20 +128,24 @@ var ActiveSkill = cc.Class.extend({
                 isCurrentPlayerHero = true;
             }
             if (this.targetType === this.ONE_ENEMY) {
-                this.targets = isCurrentPlayerHero ? [this.battle.findRandomEnemy()] : [this.battle.findRandomHero()];
+                var obj = isCurrentPlayerHero ? this.battle.findRandomEnemy() : this.battle.findRandomHero();
+                this.targets = cc.isObject(obj) ? [obj] : [];
             } else if (this.targetType === this.MULTI_HERO) {
                 this.targets = isCurrentPlayerHero ? this.battle.getAllHeroes().getAllLived():this.battle.getAllEnemies().getAllLived();
             } else if (this.targetType === this.ONE_HERO) {
-                this.targets = isCurrentPlayerHero ? [this.battle.findRandomHero()] : [this.battle.findRandomEnemy()];
+                var obj = isCurrentPlayerHero ? this.battle.findRandomHero() : this.battle.findRandomEnemy();
+                this.targets = cc.isObject(obj) ? [obj] : [obj];
             } else if (this.targetType === this.MULTI_ENEMY) {
                 this.targets = isCurrentPlayerHero ? this.battle.getAllEnemies().getAllLived():this.battle.getAllHeroes().getAllLived();
             }
         }else  if (this.targetType === this.ONE_ENEMY) {
-            this.targets = [this.battle.findNextEnemy()]
+            var enemy =  this.battle.findNextEnemy();
+            this.targets =cc.isObject(enemy) ? [enemy] : [];
         } else if (this.targetType === this.MULTI_HERO) {
             this.targets = this.battle.getAllHeroes().getAllLived();
         } else if (this.targetType === this.ONE_HERO) {
-            this.targets = [this.battle.findRandomHero()];
+            var hero =  this.battle.findRandomHero();
+            this.targets =cc.isObject(hero) ? [hero] : [];
         } else if (this.targetType === this.MULTI_ENEMY) {
             this.targets = this.battle.getAllEnemies().getAllLived();
         }
@@ -256,8 +272,8 @@ var ActiveSkill = cc.Class.extend({
     },
 
     startBuffEffect: function () {
-        if (PlayerData[this.effect]) {
-            PlayerData[this.effect] += this.effectValue;
+        if (PlayerData.create(this.playerId)[this.effect]) {
+            PlayerData.create(this.playerId)[this.effect] += this.effectValue;
         }
         for (var i in this.targets) {
             this.buffIcons[i].setScale(0.3);
@@ -267,8 +283,8 @@ var ActiveSkill = cc.Class.extend({
     },
 
     clearBuffEffect: function () {
-        if (PlayerData[this.effect]) {
-            PlayerData[this.effect] -= this.effectValue;
+        if (PlayerData.create(this.playerId)[this.effect]) {
+            PlayerData.create(this.playerId)[this.effect] -= this.effectValue;
         }
         for (var i in this.targets) {
             this.targets[i].removeBuff(this.buffIcons[i]);

--- a/src/battle/ArenaHeroUnit.js
+++ b/src/battle/ArenaHeroUnit.js
@@ -35,6 +35,7 @@ var ArenaHeroUnit = HeroUnit.extend({
             if(this.isCastSkill && this.getLife()/this.getMaxLife() * 5  < 3){
                 this.isCastSkill = false;
                 var randomSkill = this.getArenaHeroRandomSkill();
+                //console.log("randomSkill==============================="+JSON.stringify(randomSkill));
                 if(randomSkill){
                     customEventHelper.sendEvent(EVENT.CAST_SKILL,{"id":this.playerId,"skill":randomSkill});
                 }
@@ -47,6 +48,13 @@ var ArenaHeroUnit = HeroUnit.extend({
             this.battle.updateEnemyLife();
         }
     },
+    onClear: function () {
+        this._super();
+        this.tombstone.removeFromParent(this);
+        for(var i in this.buffIcons){
+            this.removeBuff(this.buffIcons[i]);
+        }
+    },
 
     onDead: function () {
         this.deadHandle();
@@ -56,7 +64,7 @@ var ArenaHeroUnit = HeroUnit.extend({
     ctor: function (battle, arenaHero) {
         this._super(battle,arenaHero);
         this.isCastSkill = true;
-        this.playerId = arenaHero._playerData.getPlayer().id;
+        this.playerId = arenaHero._playerId;
 
         if(this.playerId != player.id){
             this.setScale(-1, 1);

--- a/src/battle/BattleField.js
+++ b/src/battle/BattleField.js
@@ -170,6 +170,10 @@ var BattleField = cc.Class.extend({
             return true;
         }.bind(this), this.container);
 
+        PlayerDataClass.prototype.getArenaBattleStatus = function(){
+            return this.arenaBattle;
+        };
+
         customEventHelper.bindListener(EVENT.SHOCK_BATTLE_FIELD, function (event) {
             var duration = event.getUserData();
             var shockActions = [];
@@ -482,11 +486,12 @@ var BattleField = cc.Class.extend({
         this.enemyUnits.clear();
         for (var i = 0; i < enemiesData.length; i++) {
             var data = enemiesData[i];
+            var enemy;
             if (this.arenaBattle) {
                 //var arenaHero = new ArenaHero(data);
-                var enemy = new ArenaHeroUnit(this, data);
+                enemy = new ArenaHeroUnit(this, data);
             } else {
-                var enemy = new EnemyUnit(this, data);
+                enemy = new EnemyUnit(this, data);
                 if (bossBattle) {
                     enemy.setScale(-1.5, 1.5);
                 }
@@ -542,6 +547,8 @@ var BattleField = cc.Class.extend({
         this.enemyUnits.clear();
         this.standHeroPosNum = 0;
         this.arenaBattle = false;
+        arenaHeroPlayerData = null;
+        arenaEnemyPlayerData = null;
         delete this.challengedId;
         this.initBattle(data);
     },
@@ -569,9 +576,9 @@ var BattleField = cc.Class.extend({
 
             Network.initArenaBattle(playerId, function (result, data) {
                 if (result) {
-                    var arenaHeroPlayerData = new ArenaPlayerData();
+                    arenaHeroPlayerData = new ArenaPlayerData();
                     arenaHeroPlayerData.init(player);
-                    var arenaEnemyPlayerData = new ArenaPlayerData();
+                    arenaEnemyPlayerData = new ArenaPlayerData();
                     arenaEnemyPlayerData.init(data);
                     //this.challengedPlayer = data;
                     this.countdown.playAnimation("2", false, function () {

--- a/src/battle/BattleUnit.js
+++ b/src/battle/BattleUnit.js
@@ -195,6 +195,7 @@ var BattleUnit = CCSUnit.extend({
                 this.buffIcons.splice(i, 1);
             }
         }
+        buffEffect.stopAllActions();
         buffEffect.removeFromParent(true);
         this.refreshBuffIcons();
     },
@@ -214,6 +215,7 @@ var BattleUnit = CCSUnit.extend({
     showBuffIcons: function () {
         for (var i in this.buffIcons) {
             this.buffIcons[i].setVisible(true);
+            this.buffIcons[i].resume();
         }
     },
 
@@ -223,6 +225,7 @@ var BattleUnit = CCSUnit.extend({
     hideBuffIcons: function () {
         for (var i in this.buffIcons) {
             this.buffIcons[i].setVisible(false);
+            this.buffIcons[i].pause();
         }
     },
 

--- a/src/battle/HeroUnit.js
+++ b/src/battle/HeroUnit.js
@@ -174,6 +174,9 @@ var HeroUnit = BattleUnit.extend({
                 PlayerData.clearHeroDeadTime(this.hero.getId());
                 this.onRevive();
             }
+        }else{
+            this.showBuffIcons();
+            this.refreshBuffIcons();
         }
     }
 });

--- a/src/model/ArenaHero.js
+++ b/src/model/ArenaHero.js
@@ -1,7 +1,7 @@
 var ArenaHero = Hero.extend({
-    ctor: function (heroData, playerData) {
+    ctor: function (heroData, playerId) {
         this.init(heroData);
-        this._playerData = playerData;
+        this._playerId = playerId;
         this.initLife();
         this.refreshProps();
     },
@@ -16,7 +16,7 @@ var ArenaHero = Hero.extend({
             var value = unlock['value'];
             switch (unit) {
                 case 'hero':
-                    var hero = this._playerData.getHeroById(value);
+                    var hero = PlayerData.create(this._playerId).getHeroById(value);
                     return hero.getLv() < 1;
                 default:
             }
@@ -35,7 +35,7 @@ var ArenaHero = Hero.extend({
         if (tmpVal) {
             val += tmpVal;
         }
-        tmpVal = this._playerData["globe_" + propName + "_value"];
+        tmpVal = PlayerData.create(this._playerId)["globe_" + propName + "_value"];
         if (tmpVal) {
             val += tmpVal;
         }
@@ -43,11 +43,11 @@ var ArenaHero = Hero.extend({
         if (tmpVal) {
             rate += tmpVal / 100;
         }
-        tmpVal = this._playerData["globe_" + propName + "_rate"];
+        tmpVal = PlayerData.create(this._playerId)["globe_" + propName + "_rate"];
         if (tmpVal) {
             rate += tmpVal / 100;
         }
-        tmpVal = this._playerData["tmp_" + propName + "_rate"];
+        tmpVal = PlayerData.create(this._playerId)["tmp_" + propName + "_rate"];
         if (tmpVal) {
             rate += tmpVal / 100;
         }

--- a/src/model/ArenaPlayerData.js
+++ b/src/model/ArenaPlayerData.js
@@ -9,9 +9,11 @@ var ArenaPlayerData = PlayerDataClass.extend({
     },
     initPlayerData: function(){
         this.heroes = [];
+        var id = this.getPlayerId();
         for (var i in this._player.heroes) {
-            this.heroes.push(new ArenaHero(this._player.heroes[i],this));
+            this.heroes.push(new ArenaHero(this._player.heroes[i],id));
         }
+        this.refreshGlobeProps();
     }
 
 

--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -128,5 +128,22 @@ var player = {
     ]
 };
 var effect_props = ["life", "attack", "tap", "atk_period", "ctr_chance", "ctr_modify", "gold"];
+var PlayerData = {};
+PlayerData = new PlayerDataClass();
 
-var PlayerData = new PlayerDataClass();
+var arenaHeroPlayerData ;
+
+var arenaEnemyPlayerData ;
+
+PlayerData.create = function(playerId){
+    if(playerId){
+        if(PlayerDataClass.prototype.getArenaBattleStatus()){
+            if(playerId === player.id){
+                return arenaHeroPlayerData;
+            }else{
+                return arenaEnemyPlayerData;
+            }
+        }
+    }
+    return PlayerData;
+};

--- a/src/model/PlayerData.js
+++ b/src/model/PlayerData.js
@@ -266,40 +266,6 @@ var PlayerDataClass = cc.Class.extend({
     },
     heroes: null,
     stageData: {},
-    globe_life_value: 0,
-    globe_life_rate: 0,
-    globe_attack_value: 0,
-    globe_attack_rate: 0,
-    /**
-     * attack rate buff
-     */
-    buff_attack_rate: 0,
-    globe_tap_value: 0,
-    globe_tap_rate: 0,
-    /**
-     * tap rate buff
-     */
-    buff_tap_rate: 0,
-    globe_gold_rate: 0,
-    /**
-     * gold rate buff
-     */
-    buff_gold_rate: 0,
-    globe_atk_period_rate: 0,
-    /**
-     * attack_period rate buff
-     */
-    buff_atk_period_rate: 0,
-    globe_ctr_chance_rate: 0,
-    /**
-     * ctr_chance rate buff
-     */
-    buff_ctr_chance_rate: 0,
-    globe_ctr_modify_rate: 0,
-    /**
-     * ctr_modify rate buff
-     */
-    buff_ctr_modify_rate: 0,
     refreshGlobeProps: function () {
         /**
          * resum the globe prop from every heroes
@@ -314,6 +280,30 @@ var PlayerDataClass = cc.Class.extend({
         this.globe_atk_period_rate = 0;
         this.globe_ctr_chance_rate = 0;
         this.globe_ctr_modify_rate = 0;
+        /**
+         * attack rate buff
+         */
+        this.buff_attack_rate = 0;
+        /**
+         * tap rate buff
+         */
+        this.buff_tap_rate = 0;
+        /**
+         * gold rate buff
+         */
+        this.buff_gold_rate = 0;
+        /**
+         * attack_period rate buff
+         */
+        this.buff_atk_period_rate = 0;
+        /**
+         * ctr_chance rate buff
+         */
+        this.buff_ctr_chance_rate = 0;
+        /**
+         * ctr_modify rate buff
+         */
+        this.buff_ctr_modify_rate = 0;
         for (var i in this.heroes) {
             this.globe_life_value += this.heroes[i]["globe_life_value"];
             this.globe_life_rate += this.heroes[i]["globe_life_rate"];


### PR DESCRIPTION
ArenaHeroUnit 增加移除buff逻辑。
优化ArenaHero 将原来传入PlayerData改为传入当前角色id，增加PlayerData.create(PlayerId) 返回当前英雄角色数据。
修改移除图标后，果断时间闪动问题。
